### PR TITLE
Change script logic and fix renamed streamer issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This tool with convert Ceres files and database entries to the new Ganymede form
 ### Information
 
 * Will only work on files that are in the old format produced by Ceres. Any custom files you added will probably error out.
-* Does not delete any files, it does rename them though.
+* Does not delete any files automatically, it does rename and move them though.
 * Use this tool at your own risk and on a **fresh** Ganymede installation.
 * No Ceres DB entries are deleted.
 
@@ -15,14 +15,10 @@ This tool with convert Ceres files and database entries to the new Ganymede form
 
 This tool will log into Ceres and get all the VODs in the database. It will then create a new entry in Ganymede for each VOD. Once the database entry has been created, all VOD files will be renamed to match the new naming convention used by Ganymede.
 
-### Notes
-
-Once issue I found while running this had to do with channel names. If a streamer changed their channel/user name, you will have to manually import those VODs from that channel. An example of this is xqc. His original name was `xqcow` now it is `xqc`. I created the channel in Ganymede with `xqc` but the Ceres channel was `xqcow`. The migration tool cannot detect this and will show an error as it cannot find the channel `xqcow`. These VODs will need to be manually migrated.
-
 ### Getting Started
 
 1. Create each channel you have in Ceres in Ganymede. This is a **required** step. The tool will **not** auto create channels.
-2. Download a copy of the `docker-compose.yml` and update the Ceres host, username, password along with the Ganymede host, username and password. **Keep `SHOULD_RENAME` commented out for now. If set to true it will rename files. It is best to run a database to database migration test run first before renaming files.**
+2. Download a copy of the `docker-compose.yml` and update the Ceres host, username, password along with the Ganymede host, username and password. **Keep `SHOULD_RENAME` and `SHOULD_DELETE` commented out for now. If set to true it will rename/delete files. It is best to run a database to database migration test run first before renaming and then delete files.**
 3. Update the path to your VOD folder in the `volumes` sections. This should match the folder you have in your Ceres or Ganymede compose files.
 4. Run the `docker compose up` command.
 
@@ -39,3 +35,5 @@ If you are satisfied and want to rename VOD files follow the below steps. **Once
 3. Run the `docker compose up` command.
 
 It is likely a few files will error out because they could not be found. Take a look at the `./data/log.log` file and manually fix any rename errors.
+
+Once you are done with everything (test by playing a few VODs), you can start the container with `SHOULD_DELETE` set to true. **WARNING: It will delete every old ceres created folders, make sure everything was moved and renamed correctly in the newly created folders!**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - GANYMEDE_USERNAME=admin
       - GANYMEDE_PASSWORD=ganymede
 #      - SHOULD_RENAME=true
+#      - SHOULD_DELETE=true
     volumes:
       - ./data:/data
       - /path/to/vods:/vods

--- a/ganymede/ganymede.go
+++ b/ganymede/ganymede.go
@@ -221,9 +221,17 @@ func (s *Service) CreateVod(vod ceres.VOD, vID string, channel Channel) error {
 }
 
 func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) error {
+	// Create new vod directory
+	// https://github.com/Zibbp/ganymede-migrate/issues/1
+	newVodDir := fmt.Sprintf("/vods/%s/%s_%s", channel.Name, vod.ID, vID)
+	err := os.MkdirAll(newVodDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create new vod directory: %v", err)
+	}
+
 	var newthumbnailPath string
 	if vod.ThumbnailPath != "" {
-		newthumbnailPath = fmt.Sprintf("/vods/%s/%s/%s-thumbnail.jpg", channel.Name, vod.ID, vod.ID)
+		newthumbnailPath = fmt.Sprintf("/vods/%s/%s_%s/%s-thumbnail.jpg", channel.Name, vod.ID, vID, vod.ID)
 		oldThumbnailPath := fmt.Sprintf("/vods/%s", vod.ThumbnailPath)
 		err := os.Rename(oldThumbnailPath, newthumbnailPath)
 		if err != nil {
@@ -234,7 +242,7 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	}
 	var newwebThumbnailPath string
 	if vod.ThumbnailPath != "" {
-		newwebThumbnailPath = fmt.Sprintf("/vods/%s/%s/%s-web_thumbnail.jpg", channel.Name, vod.ID, vod.ID)
+		newwebThumbnailPath = fmt.Sprintf("/vods/%s/%s_%s/%s-web_thumbnail.jpg", channel.Name, vod.ID, vID, vod.ID)
 		oldWebThumbnailPath := fmt.Sprintf("/vods/%s", vod.WebThumbnailPath)
 		err := os.Rename(oldWebThumbnailPath, newwebThumbnailPath)
 		if err != nil {
@@ -245,7 +253,7 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	}
 	var newvideoPath string
 	if vod.VideoPath != "" {
-		newvideoPath = fmt.Sprintf("/vods/%s/%s/%s-video.mp4", channel.Name, vod.ID, vod.ID)
+		newvideoPath = fmt.Sprintf("/vods/%s/%s_%s/%s-video.mp4", channel.Name, vod.ID, vID, vod.ID)
 		oldVideoPath := fmt.Sprintf("/vods/%s", vod.VideoPath)
 		err := os.Rename(oldVideoPath, newvideoPath)
 		if err != nil {
@@ -256,7 +264,7 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	}
 	var newchatPath string
 	if vod.ChatPath != "" {
-		newchatPath = fmt.Sprintf("/vods/%s/%s/%s-chat.json", channel.Name, vod.ID, vod.ID)
+		newchatPath = fmt.Sprintf("/vods/%s/%s_%s/%s-chat.json", channel.Name, vod.ID, vID, vod.ID)
 		oldChatPath := fmt.Sprintf("/vods/%s", vod.ChatPath)
 		err := os.Rename(oldChatPath, newchatPath)
 		if err != nil {
@@ -267,7 +275,7 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	}
 	var newchatVideoPath string
 	if vod.ChatVideoPath != "" {
-		newchatVideoPath = fmt.Sprintf("/vods/%s/%s/%s-chat.mp4", channel.Name, vod.ID, vod.ID)
+		newchatVideoPath = fmt.Sprintf("/vods/%s/%s_%s/%s-chat.mp4", channel.Name, vod.ID, vID, vod.ID)
 		oldChatVideoPath := fmt.Sprintf("/vods/%s", vod.ChatVideoPath)
 		err := os.Rename(oldChatVideoPath, newchatVideoPath)
 		if err != nil {
@@ -278,7 +286,7 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	}
 	var newinfoPath string
 	if vod.VODInfoPath != "" {
-		newinfoPath = fmt.Sprintf("/vods/%s/%s/%s-info.json", channel.Name, vod.ID, vod.ID)
+		newinfoPath = fmt.Sprintf("/vods/%s/%s_%s/%s-info.json", channel.Name, vod.ID, vID, vod.ID)
 		oldInfoPath := fmt.Sprintf("/vods/%s", vod.VODInfoPath)
 		err := os.Rename(oldInfoPath, newinfoPath)
 		if err != nil {
@@ -287,10 +295,13 @@ func (s *Service) RenameVodFiles(vod ceres.VOD, vID string, channel Channel) err
 	} else {
 		newinfoPath = ""
 	}
-	// Folder rename
-	err := os.Rename(fmt.Sprintf("/vods/%s/%s", channel.Name, vod.ID), fmt.Sprintf("/vods/%s/%s_%s", channel.Name, vod.ID, vID))
+	return nil
+}
+
+func (s *Service) RemoveOldFolders(vod ceres.VOD, vID string, channel Channel) error {
+	err := os.RemoveAll(fmt.Sprintf("/vods/%s/%s", channel.Name, vod.ID))
 	if err != nil {
-		log.Printf("failed to rename vod folder: %v", err)
+		log.Printf("failed to remove vod folder: %v", err)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -46,19 +46,19 @@ func main() {
 	shouldDelete := os.Getenv("SHOULD_DELETE")
 
 	for _, vod := range vods {
+		// Get channel from Ganymede
+		channel, err := ganymedeService.GetChannel(vod.Channel.Login)
+		if err != nil {
+			log.Printf("Skipping VOD: %s because of: GetChannel failed: %v", vod.ID, err)
+			failedVods = append(failedVods, vod)
+			continue
+		}
+		// Generate UUID for VOD creation
+		vID, err := uuid.NewUUID()
+		if err != nil {
+			log.Panicf("Failed to generate UUID: %v", err)
+		}
 		if shouldDelete != "true" {
-			// Get channel from Ganymede
-			channel, err := ganymedeService.GetChannel(vod.Channel.Login)
-			if err != nil {
-				log.Printf("Skipping VOD: %s because of: GetChannel failed: %v", vod.ID, err)
-				failedVods = append(failedVods, vod)
-				continue
-			}
-			// Generate UUID for VOD creation
-			vID, err := uuid.NewUUID()
-			if err != nil {
-				log.Panicf("Failed to generate UUID: %v", err)
-			}
 			// Create VOD in Ganymede
 			err = ganymedeService.CreateVod(vod, vID.String(), channel)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -43,37 +43,51 @@ func main() {
 	var failedVods []ceres.VOD
 
 	shouldRename := os.Getenv("SHOULD_RENAME")
+	shouldDelete := os.Getenv("SHOULD_DELETE")
 
 	for _, vod := range vods {
-		// Get channel from Ganymede
-		channel, err := ganymedeService.GetChannel(vod.Channel.Login)
-		if err != nil {
-			log.Printf("Skipping VOD: %s because of: GetChannel failed: %v", vod.ID, err)
-			failedVods = append(failedVods, vod)
-			continue
-		}
-		// Generate UUID for VOD creation
-		vID, err := uuid.NewUUID()
-		if err != nil {
-			log.Panicf("Failed to generate UUID: %v", err)
-		}
-		// Create VOD in Ganymede
-		err = ganymedeService.CreateVod(vod, vID.String(), channel)
-		if err != nil {
-			if err.Error() == "vod already exists" {
+		if shouldDelete != "true" {
+			// Get channel from Ganymede
+			channel, err := ganymedeService.GetChannel(vod.Channel.Login)
+			if err != nil {
+				log.Printf("Skipping VOD: %s because of: GetChannel failed: %v", vod.ID, err)
+				failedVods = append(failedVods, vod)
 				continue
-			} else {
-				log.Printf("Skipping VOD: %s because of: CreateVod failed: %v", vod.ID, err)
+			}
+			// Generate UUID for VOD creation
+			vID, err := uuid.NewUUID()
+			if err != nil {
+				log.Panicf("Failed to generate UUID: %v", err)
+			}
+			// Create VOD in Ganymede
+			err = ganymedeService.CreateVod(vod, vID.String(), channel)
+			if err != nil {
+				if err.Error() == "vod already exists" {
+					continue
+				} else {
+					log.Printf("Skipping VOD: %s because of: CreateVod failed: %v", vod.ID, err)
+					failedVods = append(failedVods, vod)
+					continue
+				}
+			}
+		}
+		
+		// Rename VOD files for Ganymede
+		// Only run if ENV SHOULD_RENAME is set to true and ENV SHOULD_DELETE is not set
+		if shouldRename == "true" && shouldDelete != "true" {
+			err = ganymedeService.RenameVodFiles(vod, vID.String(), channel)
+			if err != nil {
+				log.Printf("Skipping VOD: %s because of: RenameVodFiles failed: %v", vod.ID, err)
 				failedVods = append(failedVods, vod)
 				continue
 			}
 		}
-		// Rename VOD files for Ganymede
-		// Only run if ENV SHOULD_RENAME is set to true
-		if shouldRename == "true" {
-			err = ganymedeService.RenameVodFiles(vod, vID.String(), channel)
+		// Remove old VOD folders from ceres
+		// Only run if ENV SHOULD_DELETE is set to true
+		if shouldDelete == "true" {
+			err = ganymedeService.RemoveOldFolders(vod, vID.String(), channel)
 			if err != nil {
-				log.Printf("Skipping VOD: %s because of: RenameVodFiles failed: %v", vod.ID, err)
+				log.Printf("Skipping VOD: %s because of: RemoveOldFolders failed: %v", vod.ID, err)
 				failedVods = append(failedVods, vod)
 				continue
 			}


### PR DESCRIPTION
## Changes
- Script logic changed from folder rename to create folder, move files and then delete old folder
- Fix the renamed streamer issue from #1

### Why change the script logic?
When I checked the code, I've seen you moved files into the same folder to another name and then finally rename the folder to the new UUID one. To fix the renamed streamer issue, I needed to create a new folder (because the VODID don't exist under the new name) to move and rename the needed files. I could create a old named folder like "123456789" and then rename the folder at the end but it was better (in my opinion) to create the new UUID one from the start.

### New `SHOULD_DELETE` env
Since the logic was changed to create new folder, older ones are still there. I decided to not automatically delete them because it can contains files with rename errors and because I wanted to give users time to check everything is fine before fully deleting any trace of ceres. Some if statements have been added to make sure that the rename function and the VODs injection in DB don't start when deletion process is started.

---

Let me know of any change you want to make, since I'm not familiar with this language, I tried my best to add everything I had around my head.